### PR TITLE
Fix requirements.txt file to avoid installation errors

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,7 @@ pandas==1.3.5
 librosa==0.8.1
 pyctcdecode==0.4.0
 jiwer==2.5.1
+numpy==1.22.4
+huggingface-hub==0.10.1
+librosa==0.8.1
+fsspec==2023.9.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,5 @@ lxml==4.9.1
 sphfile==1.0.3
 pandas==1.3.5
 librosa==0.8.1
-pyctcdecode=0.4.0
+pyctcdecode==0.4.0
 jiwer==2.5.1


### PR DESCRIPTION
There is a typo in requirements.txt which prevents the installation of the dependencies.